### PR TITLE
Update github action to support pre-relases

### DIFF
--- a/.github/workflows/publish-to-npmjs.yml
+++ b/.github/workflows/publish-to-npmjs.yml
@@ -18,6 +18,13 @@ jobs:
           node-version: "20.x"
           registry-url: "https://registry.npmjs.org"
       - run: npm ci
-      - run: npm publish --provenance --access public
+      - run: |
+          if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
+            echo "Publishing pre-release to npm with tag 'next'"
+            npm publish --tag next --provenance --access public
+          else
+            echo "Publishing stable release to npm with tag 'latest'"
+            npm publish --provenance --access public
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "straumur-web-component",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "license": "MIT",
   "homepage": "https://docs.straumur.is",
   "type": "module",


### PR DESCRIPTION
This pull request introduces an improvement to the npm publishing workflow and updates the package version. The most significant change is the enhancement to the GitHub Actions workflow, which now automatically publishes pre-releases with the npm tag 'next' and stable releases with the tag 'latest'.