### PR TITLE
Refactor NPM publish workflow: add reusable action, GitHub release & manual triggers

### DIFF
--- a/.github/workflows/github-release-trigger.yml
+++ b/.github/workflows/github-release-trigger.yml
@@ -6,3 +6,5 @@ on:
 jobs:
   publish-to-npmjs:
     uses: ./.github/workflows/publish-to-npmjs.yml
+    with:
+      prerelease: ${{ github.event.release.prerelease }}

--- a/.github/workflows/github-release-trigger.yml
+++ b/.github/workflows/github-release-trigger.yml
@@ -1,0 +1,8 @@
+name: Github release trigger
+
+on:
+  release:
+    types: [published]
+jobs:
+  publish-to-npmjs:
+    uses: ./.github/workflows/publish-to-npmjs.yml

--- a/.github/workflows/manual-pre-release-to-npmjs.yml
+++ b/.github/workflows/manual-pre-release-to-npmjs.yml
@@ -1,0 +1,7 @@
+name: Manual pre-release publish to NPM
+
+on: workflow_dispatch
+
+jobs:
+  publish-to-npmjs:
+    uses: ./.github/workflows/publish-to-npmjs.yml

--- a/.github/workflows/manual-pre-release-to-npmjs.yml
+++ b/.github/workflows/manual-pre-release-to-npmjs.yml
@@ -5,3 +5,5 @@ on: workflow_dispatch
 jobs:
   publish-to-npmjs:
     uses: ./.github/workflows/publish-to-npmjs.yml
+    with:
+      prerelease: true

--- a/.github/workflows/publish-to-npmjs.yml
+++ b/.github/workflows/publish-to-npmjs.yml
@@ -1,28 +1,38 @@
 # For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
 
 name: Publish Package to npmjs
-on: workflow_call
+on:
+  workflow_call:
+    inputs:
+      prerelease:
+        required: true
+        type: boolean
 jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - uses: actions/checkout@v4
-      # Setup .npmrc file to publish to npm
+
       - uses: actions/setup-node@v4
         with:
           node-version: "20.x"
           registry-url: "https://registry.npmjs.org"
+
       - run: npm ci
-      - run: |
-          if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
-            echo "Publishing pre-release to npm with tag 'next'"
-            npm publish --tag next --provenance --access public
-          else
-            echo "Publishing stable release to npm with tag 'latest'"
-            npm publish --provenance --access public
-          fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publishing pre-release
+        if: ${{ inputs.prerelease }}
+        run: |
+          echo "Publishing pre-release to npm with tag 'next'"
+          npm publish --tag next --provenance --access public
+
+      - name: Publishing stable release
+        if: ${{ !inputs.prerelease }}
+        run: |
+          echo "Publishing stable release to npm with tag 'latest'"
+          npm publish --provenance --access public

--- a/.github/workflows/publish-to-npmjs.yml
+++ b/.github/workflows/publish-to-npmjs.yml
@@ -1,9 +1,7 @@
 # For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
 
 name: Publish Package to npmjs
-on:
-  release:
-    types: [published]
+on: workflow_call
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request refactors and improves the NPM publishing workflow by introducing reusable GitHub Actions, making the release process more flexible and maintainable. The main changes include splitting the publishing logic into a reusable workflow, adding a manual pre-release trigger, and improving environment variable handling.

Workflow refactoring and reusability:

* Refactored `.github/workflows/publish-to-npmjs.yml` to be a reusable workflow using `workflow_call` with an explicit `prerelease` boolean input, and moved the logic for handling pre-releases and stable releases into separate steps.
* Updated environment variable handling by moving `NODE_AUTH_TOKEN` to the `env` section at the job level for better security and clarity.

Release process automation:

* Added `.github/workflows/github-release-trigger.yml` to automatically trigger the NPM publish workflow on GitHub release publication, passing the pre-release status as an input.
* Added `.github/workflows/manual-pre-release-to-npmjs.yml` to allow manual triggering of pre-release publishing to NPM via the GitHub Actions UI, always setting `prerelease: true`.