### PR TITLE
Changes to make Github publish to NPM possible

### DIFF
--- a/.github/workflows/github-release-trigger.yml
+++ b/.github/workflows/github-release-trigger.yml
@@ -8,5 +8,3 @@ jobs:
     uses: ./.github/workflows/publish-to-npmjs.yml
     with:
       prerelease: ${{ github.event.release.prerelease }}
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/manual-pre-release-to-npmjs.yml
+++ b/.github/workflows/manual-pre-release-to-npmjs.yml
@@ -7,5 +7,3 @@ jobs:
     uses: ./.github/workflows/publish-to-npmjs.yml
     with:
       prerelease: true
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-to-npmjs.yml
+++ b/.github/workflows/publish-to-npmjs.yml
@@ -8,17 +8,13 @@ on:
         required: true
         type: boolean
 
-    secrets:
-      NPM_TOKEN:
-        required: true
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-    env:
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows related to publishing to npm. The main change is the removal of explicit secrets passing (specifically `NPM_TOKEN`) in favor of using OpenID Connect (OIDC) authentication for npm publishing, which is a more secure and modern approach.