### PR TITLE
SD-3134: Automate CDN publishing of eComponents to S3 + CloudFront

### DIFF
--- a/.github/workflows/publish-to-cdn.yml
+++ b/.github/workflows/publish-to-cdn.yml
@@ -1,0 +1,125 @@
+name: Publish Package to CDN
+
+on:
+  workflow_run:
+    workflows: ["Publish Package to npmjs"]
+    types: [completed]
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'release')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - run: npm ci
+
+      - name: Build library
+        run: npm run build
+
+      - name: Read package version
+        id: pkg
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Upload versioned build (immutable)
+        env:
+          BUCKET: ${{ secrets.CDN_S3_BUCKET }}
+          VERSION: ${{ steps.pkg.outputs.version }}
+        run: |
+          DEST="s3://$BUCKET/libs/straumur-web-component/$VERSION/"
+          aws s3 cp dist/ "$DEST" \
+            --recursive \
+            --exclude "*" \
+            --include "index.js" \
+            --include "index.mjs" \
+            --include "index.js.map" \
+            --include "index.mjs.map" \
+            --include "index.d.ts" \
+            --cache-control "public, max-age=31536000, immutable" \
+            --only-show-errors
+
+      - name: Upload "latest" build (short cache)
+        env:
+          BUCKET: ${{ secrets.CDN_S3_BUCKET }}
+        run: |
+          DEST="s3://$BUCKET/libs/straumur-web-component/latest/"
+          aws s3 cp dist/ "$DEST" \
+            --recursive \
+            --exclude "*" \
+            --include "index.js" \
+            --include "index.mjs" \
+            --include "index.js.map" \
+            --include "index.mjs.map" \
+            --include "index.d.ts" \
+            --cache-control "public, max-age=300, must-revalidate" \
+            --only-show-errors
+
+      - name: Invalidate CloudFront cache for "latest"
+        env:
+          DIST_ID: ${{ secrets.CDN_CLOUDFRONT_ID }}
+        run: |
+          if [ -z "$DIST_ID" ]; then
+            echo "CDN_CLOUDFRONT_ID not set; skipping invalidation."
+            exit 0
+          fi
+          aws cloudfront create-invalidation \
+            --distribution-id "$DIST_ID" \
+            --paths "/libs/straumur-web-component/latest/*" \
+            --output text --query 'Invalidation.Status'
+
+      - name: Generate SRI hashes and summary
+        env:
+          VERSION: ${{ steps.pkg.outputs.version }}
+          CDN_BASE_URL: ${{ vars.CDN_BASE_URL }}
+        run: |
+          sri_js=$(openssl dgst -sha384 -binary dist/index.js | openssl base64 -A)
+          sri_mjs=$(openssl dgst -sha384 -binary dist/index.mjs | openssl base64 -A)
+
+          BASE="${CDN_BASE_URL:-https://<your-cdn-domain>}"
+
+          {
+            echo "## Straumur Web Component — CDN publish"
+            echo ""
+            echo "**Version:** \`$VERSION\`"
+            echo ""
+            echo "### IIFE bundle (global \`StraumurWeb\`)"
+            echo '```html'
+            echo "<script src=\"$BASE/libs/straumur-web-component/$VERSION/index.js\""
+            echo "        integrity=\"sha384-$sri_js\""
+            echo "        crossorigin=\"anonymous\"></script>"
+            echo '```'
+            echo ""
+            echo "### ESM module"
+            echo '```html'
+            echo "<script type=\"module\">"
+            echo "  import { StraumurCheckout } from \"$BASE/libs/straumur-web-component/$VERSION/index.mjs\";"
+            echo "</script>"
+            echo '```'
+            echo ""
+            echo "**SRI (index.js):** \`sha384-$sri_js\`"
+            echo ""
+            echo "**SRI (index.mjs):** \`sha384-$sri_mjs\`"
+            echo ""
+            echo "_Also published under \`latest/\` (no SRI — use a pinned version for integrity)._"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,55 @@
 # straumur-web-component
+
+Straumur eComponents — embeddable checkout components for merchants.
+
+## Installation
+
+### npm
+
+```bash
+npm install straumur-web-component
+```
+
+```ts
+import { StraumurCheckout } from "straumur-web-component";
+```
+
+### CDN
+
+The library is published to a CDN on every GitHub Release. Each release is
+available under an immutable, version-pinned URL (recommended for production)
+and a mutable `latest/` URL.
+
+**IIFE bundle** — exposes the global `StraumurWeb`:
+
+```html
+<script
+  src="https://<your-cdn-domain>/libs/straumur-web-component/<version>/index.js"
+  integrity="sha384-..."
+  crossorigin="anonymous"
+></script>
+<script>
+  // window.StraumurWeb.StraumurCheckout
+</script>
+```
+
+**ESM module:**
+
+```html
+<script type="module">
+  import { StraumurCheckout } from "https://<your-cdn-domain>/libs/straumur-web-component/<version>/index.mjs";
+</script>
+```
+
+The exact versioned URL and the matching [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity)
+(`integrity`) hash for each release are printed in that release's GitHub Actions
+run summary (the "Publish Package to CDN" workflow). Always pin to a specific
+version with its SRI hash in production; the `latest/` path is convenient for
+testing but is not integrity-pinned.
+
+## Publishing
+
+- **npm** — `.github/workflows/publish-to-npmjs.yml` publishes to npmjs on release.
+- **CDN** — `.github/workflows/publish-to-cdn.yml` builds and uploads to AWS S3
+  (fronted by CloudFront) on release. See the comments at the top of that file
+  for the required GitHub secrets and variables.


### PR DESCRIPTION
## SD-3134 — Host Straumur eComponents on a CDN

Adds an automated GitHub Actions workflow that publishes the built library to AWS S3 (fronted by CloudFront) so merchants can integrate via a CDN URL instead of pulling from npm.

### What it does
- **Triggers after a successful npm release publish** (`workflow_run` chained to `Publish Package to npmjs`), so a release lands on npm first, then the CDN — no half-published releases. Manual `workflow_dispatch` is available for testing.
- **Builds** the existing tsup bundles (IIFE `index.js` w/ global `StraumurWeb`, ESM `index.mjs`, source maps, types).
- **Uploads to S3** under an immutable, version-pinned path (`libs/straumur-web-component/<version>/`, cached 1y) plus a mutable `latest/` path (short cache).
- **Invalidates CloudFront** for `latest/*` after upload.
- **Generates SRI (`sha384`) hashes** and prints ready-to-paste `<script>` snippets to the run summary.

### Public-repo hardening
- Bucket name and distribution ID are stored as **Secrets** (masked in public logs), not Variables.
- `aws s3 cp --only-show-errors` so the bucket path isn't printed in logs.
- No infrastructure details committed to the repo.

### Files
- `.github/workflows/publish-to-cdn.yml` — the workflow
- `README.md` — merchant-facing CDN usage

### Required setup before this works
Configure the AWS secrets/variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `CDN_S3_BUCKET`, `CDN_CLOUDFRONT_ID` as **secrets**; `AWS_REGION`, `CDN_BASE_URL` as **variables**) under Settings → Secrets and variables → Actions. The IAM key should be least-privilege (`s3:PutObject` on the bucket prefix + `cloudfront:CreateInvalidation` on the one distribution).

> Note: the `workflow_run` coupling only activates once this file is on the default branch (`dev`); before that, test via `workflow_dispatch`.
